### PR TITLE
BUGFIX utilize ProductExpirationHelper on AddToCartForm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "dynamic/silverstripe-foxy": "^1.0",
+        "dynamic/silverstripe-foxy": "^1.3.2",
         "dynamic/silverstripe-foxy-orders": "^1.0",
         "unclecheese/display-logic": "^2.0"
     },

--- a/src/Extension/AddToCartFormExtension.php
+++ b/src/Extension/AddToCartFormExtension.php
@@ -10,6 +10,12 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HeaderField;
 use SilverStripe\Forms\HiddenField;
 
+/**
+ * Class AddToCartFormExtension
+ * @package Dynamic\Foxy\Inventory\Extension
+ *
+ * @property-read AddToCartFormExtension|AddToCartForm $owner
+ */
 class AddToCartFormExtension extends Extension
 {
     /**
@@ -18,18 +24,7 @@ class AddToCartFormExtension extends Extension
     public function updateProductFields(FieldList &$fields)
     {
         if ($this->owner->getProduct()->CartExpiration) {
-            $fields->insertAfter(
-                'weight',
-                HiddenField::create('expires')
-                    ->setValue(
-                        AddToCartForm::getGeneratedValue(
-                            $this->owner->getProduct()->Code,
-                            'expires',
-                            $this->owner->getProduct()->ExpirationMinutes,
-                            'value'
-                        )
-                    )
-            );
+            $this->owner->getExpirationHelper()->addExpiration($this->owner->getProduct()->ExpirationMinutes);
         }
 
         if ($this->isOutOfStock()) {


### PR DESCRIPTION
Currently there is no way for multiple foxy modules implementing an `expires` to intelligently determine the lowest time in minutes. The helper does that for us.

Depends on dynamic/silverstripe-foxy#121